### PR TITLE
New feature: Bundle Offers

### DIFF
--- a/python/enums.py
+++ b/python/enums.py
@@ -11,3 +11,7 @@ class SpecialOfferType(Enum):
     TEN_PERCENT_DISCOUNT = 2
     TWO_FOR_AMOUNT = 3
     FIVE_FOR_AMOUNT = 4
+
+
+class BundleOfferType(Enum):
+    TEN_PERCENT_DISCOUNT = 1

--- a/python/model_objects.py
+++ b/python/model_objects.py
@@ -30,6 +30,13 @@ class Offer:
         self.argument = argument
 
 
+class BundleOffer:
+    def __init__(self, offer_type, product_quantities, argument):
+        self.offer_type = offer_type
+        self.product_quantities = product_quantities
+        self.argument = argument
+
+
 class Discount:
     def __init__(self, product, description, discount_amount):
         self.product = product

--- a/python/teller.py
+++ b/python/teller.py
@@ -1,5 +1,5 @@
 import math
-from model_objects import Offer, Receipt, Discount
+from model_objects import Offer, BundleOffer, Receipt, Discount
 from enums import SpecialOfferType
 
 
@@ -8,9 +8,13 @@ class Teller:
     def __init__(self, catalog):
         self.catalog = catalog
         self.offers = {}
+        self.bundle_offers = []
 
     def add_special_offer(self, offer_type, product, argument):
         self.offers[product] = Offer(offer_type, product, argument)
+
+    def add_bundle_offer(self, offer_type, product_quantites, argument):
+        self.bundle_offers.append(BundleOffer(offer_type, product_quantites, argument))
 
     def checks_out_articles_from(self, the_cart):
         receipt = Receipt()

--- a/python/teller.py
+++ b/python/teller.py
@@ -1,6 +1,6 @@
 import math
 from model_objects import Offer, BundleOffer, Receipt, Discount
-from enums import SpecialOfferType
+from enums import SpecialOfferType, BundleOfferType
 
 
 class Teller:
@@ -23,21 +23,29 @@ class Teller:
             product = pq.product
             receipt.add_product(product, pq.quantity, self.catalog.unit_price(product))
 
-        self.handle_offers(the_cart, receipt)
+        self.__handle_offers(the_cart, receipt)
 
         return receipt
-
-    def handle_offers(self, the_cart, receipt):
-        for product in the_cart._product_quantities.keys():
-            quantity = the_cart._product_quantities[product]
-            discount = self.__compute_discount(product, quantity)
-            if discount:
-                receipt.add_discount(discount)
 
     def product_with_name(self, name):
         return self.catalog.products.get(name, None)
 
-    def __compute_discount(self, product, quantity):
+    def __handle_offers(self, the_cart, receipt):   
+        bundles_in_cart = self.__find_bundles_in_cart(the_cart)   
+        for product in the_cart._product_quantities.keys():
+            discount = self.__compute_discounts(product, the_cart, bundles_in_cart)
+            if discount:
+                receipt.add_discount(discount)
+
+    def __compute_discounts(self, product, the_cart, bundles_in_cart):
+        quantity = the_cart._product_quantities[product]
+        discount = self.__compute_discount_for_bundles(product, quantity, the_cart, bundles_in_cart)
+        if not discount:
+            discount = self.__compute_discount_for_single_products(product, quantity)
+        
+        return discount
+
+    def __compute_discount_for_single_products(self, product, quantity):
         discount = None
         if product in self.offers.keys():
             offer = self.offers[product]
@@ -53,8 +61,47 @@ class Teller:
             
             elif offer.offer_type == SpecialOfferType.TEN_PERCENT_DISCOUNT:
                 discount = self.__compute_discount_for_x_percent_discount_offer(product, quantity)
-        
+            
         return discount
+
+    def __compute_discount_for_bundles(self, product, quantity, the_cart, bundles_in_cart):
+        max_discount = None
+        for bundle in bundles_in_cart:
+            if product in bundle.product_quantities.keys():
+                if bundle.offer_type == BundleOfferType.TEN_PERCENT_DISCOUNT:
+                    bundle_frequency = self.__get_frequency_of_bundle(the_cart, bundle)
+                    discount = self.__compute_discount_for_x_percent_bundle_discount_offer(product, quantity, bundle, bundle_frequency)
+                    if not max_discount or max_discount.discount_amount < discount.discount_amount:
+                        max_discount = discount
+
+        return max_discount
+
+    def __get_frequency_of_bundle(self, the_cart, bundle_offer):
+        frequencies = [quantity // bundle_offer.product_quantities[product] for product, quantity in the_cart._product_quantities.items() if product in bundle_offer.product_quantities.keys()]
+        return min(frequencies)
+
+    def __find_bundles_in_cart(self, the_cart):
+        bundles_in_cart = []
+        for bundle_offer in self.bundle_offers:
+            if self.__bundle_exists_in_cart(the_cart, bundle_offer):
+                bundles_in_cart.append(bundle_offer)
+
+        return bundles_in_cart
+
+    def __bundle_exists_in_cart(self, the_cart, bundle_offer):
+        cart_products = the_cart._product_quantities.keys()
+        bundle_products = bundle_offer.product_quantities.keys()
+        is_match = True
+        if len(cart_products) < len(bundle_products):
+            is_match = False
+        else:
+            for bundle_product in bundle_products:
+                if bundle_product not in cart_products \
+                or the_cart._product_quantities[bundle_product] < bundle_offer.product_quantities[bundle_product]:
+                    is_match = False
+                    break
+
+        return is_match
 
     def __compute_discount_for_X_for_amount_offer(self, product, quantity, X):
         offer = self.offers[product]
@@ -63,7 +110,8 @@ class Teller:
         unit_price = self.catalog.unit_price(product)
         discounted_total = offer.argument * number_of_x + quantity_as_int % X * unit_price
         discount_amount = unit_price * quantity - discounted_total
-        return Discount(product, str(X) + " for " + str(offer.argument), -discount_amount)
+        discount_description = f"{X} for {offer.argument}"
+        return Discount(product, discount_description, -discount_amount)
 
     def __compute_discount_for_X_for_Y_offer(self, product, quantity, X, Y):
         quantity_as_int = int(quantity)
@@ -71,12 +119,24 @@ class Teller:
         unit_price = self.catalog.unit_price(product)
         discounted_total = (number_of_x * Y * unit_price) + quantity_as_int % X * unit_price
         discount_amount =  unit_price * quantity - discounted_total
-        return Discount(product, str(X) + " for " + str(Y), -discount_amount)
+        discount_description = f"{X} for {Y}"
+        return Discount(product, discount_description, -discount_amount)
 
     def __compute_discount_for_x_percent_discount_offer(self, product, quantity):
         offer = self.offers[product]
         unit_price = self.catalog.unit_price(product)
         discount_amount =  unit_price * quantity * offer.argument / 100.0
-        discount = Discount(product, str(offer.argument) + "% off", -discount_amount)
+        discount_description = f"{offer.argument}% off"
+        discount = Discount(product, discount_description, -discount_amount)
+        return discount
+
+    def __compute_discount_for_x_percent_bundle_discount_offer(self, product, quantity, bundle_offer, bundle_frequency):
+        discount = None
+        if product in bundle_offer.product_quantities.keys():
+            unit_price = self.catalog.unit_price(product)
+            discount_quantity = bundle_offer.product_quantities[product] * bundle_frequency
+            discount_amount =  unit_price * discount_quantity * bundle_offer.argument / 100.0
+            discount_description = f"{bundle_frequency}x{bundle_offer.argument}% bundle offer"
+            discount = Discount(product, discount_description, -discount_amount)
         return discount
     

--- a/python/teller.py
+++ b/python/teller.py
@@ -139,4 +139,3 @@ class Teller:
             discount_description = f"{bundle_frequency}x{bundle_offer.argument}% bundle offer"
             discount = Discount(product, discount_description, -discount_amount)
         return discount
-    

--- a/python/teller.py
+++ b/python/teller.py
@@ -71,7 +71,7 @@ class Teller:
                 if bundle.offer_type == BundleOfferType.TEN_PERCENT_DISCOUNT:
                     bundle_frequency = self.__get_frequency_of_bundle(the_cart, bundle)
                     discount = self.__compute_discount_for_x_percent_bundle_discount_offer(product, quantity, bundle, bundle_frequency)
-                    if not max_discount or max_discount.discount_amount < discount.discount_amount:
+                    if not max_discount or max_discount.discount_amount > discount.discount_amount:
                         max_discount = discount
 
         return max_discount

--- a/python/tests/approved_files/SupermarketTest.test_bundle_offer_and_single_offer_together.approved.txt
+++ b/python/tests/approved_files/SupermarketTest.test_bundle_offer_and_single_offer_together.approved.txt
@@ -1,0 +1,9 @@
+toothbrush                          0.99
+toothpaste                          1.49
+rice                                8.97
+  2.99 * 3
+1x10% bundle offer (toothbrush)    -0.10
+1x10% bundle offer (toothpaste)    -0.15
+3 for 2 (rice)                     -2.99
+
+Total:                              8.21

--- a/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle.approved.txt
+++ b/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle.approved.txt
@@ -1,0 +1,6 @@
+toothbrush                          0.99
+toothpaste                          1.49
+1x10% bundle offer (toothbrush)    -0.10
+1x10% bundle offer (toothpaste)    -0.15
+
+Total:                              2.23

--- a/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle_no_match.approved.txt
+++ b/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle_no_match.approved.txt
@@ -1,0 +1,4 @@
+apples                              1.99
+rice                                2.99
+
+Total:                              4.98

--- a/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle_with_extra_items.approved.txt
+++ b/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle_with_extra_items.approved.txt
@@ -1,0 +1,8 @@
+toothbrush                          0.99
+toothpaste                          1.49
+cherry tomato box                   0.34
+  0.69 * 0.5
+1x10% bundle offer (toothbrush)    -0.10
+1x10% bundle offer (toothpaste)    -0.15
+
+Total:                              2.58

--- a/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle_with_extra_quantity.approved.txt
+++ b/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle_with_extra_quantity.approved.txt
@@ -1,0 +1,7 @@
+toothbrush                          1.98
+  0.99 * 2
+toothpaste                          1.49
+1x10% bundle offer (toothbrush)    -0.10
+1x10% bundle offer (toothpaste)    -0.15
+
+Total:                              3.22

--- a/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle_with_multiples.approved.txt
+++ b/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle_with_multiples.approved.txt
@@ -1,0 +1,8 @@
+toothbrush                          2.97
+  0.99 * 3
+toothpaste                          7.45
+  1.49 * 5
+3x10% bundle offer (toothbrush)    -0.30
+3x10% bundle offer (toothpaste)    -0.45
+
+Total:                              9.68

--- a/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle_with_per_kilo_items.approved.txt
+++ b/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle_with_per_kilo_items.approved.txt
@@ -1,0 +1,8 @@
+apples                              3.98
+  1.99 * 2.000
+cherry tomato box                   2.07
+  0.69 * 3.0
+2.0x10% bundle offer (apples)      -0.40
+2.0x10% bundle offer (cherry tomato box)-0.14
+
+Total:                              5.51

--- a/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle_with_too_few_items.approved.txt
+++ b/python/tests/approved_files/SupermarketTest.test_percent_discount_on_bundle_with_too_few_items.approved.txt
@@ -1,0 +1,4 @@
+toothbrush                          0.99
+toothpaste                          1.49
+
+Total:                              2.48

--- a/python/tests/approved_files/SupermarketTest.test_percent_discount_on_multiple_bundles.approved.txt
+++ b/python/tests/approved_files/SupermarketTest.test_percent_discount_on_multiple_bundles.approved.txt
@@ -1,0 +1,13 @@
+apples                              3.98
+  1.99 * 2.000
+rice                                2.99
+cherry tomato box                   2.07
+  0.69 * 3.0
+toothbrush                          0.99
+toothpaste                          1.49
+1.0x10% bundle offer (apples)      -0.20
+1.0x10% bundle offer (rice)        -0.30
+1x10% bundle offer (toothbrush)    -0.10
+1x10% bundle offer (toothpaste)    -0.15
+
+Total:                             10.77

--- a/python/tests/approved_files/SupermarketTest.test_percent_discount_on_multiple_bundles_with_redundant_item.approved.txt
+++ b/python/tests/approved_files/SupermarketTest.test_percent_discount_on_multiple_bundles_with_redundant_item.approved.txt
@@ -1,0 +1,10 @@
+rice                                2.99
+toothbrush                          9.90
+  0.99 * 10
+toothpaste                         14.90
+  1.49 * 10
+1.0x10% bundle offer (rice)        -0.30
+10x10% bundle offer (toothbrush)   -0.99
+10x10% bundle offer (toothpaste)   -1.49
+
+Total:                             25.01

--- a/python/tests/test_supermarket.py
+++ b/python/tests/test_supermarket.py
@@ -180,3 +180,22 @@ class SupermarketTest(unittest.TestCase):
         self.teller.add_bundle_offer(BundleOfferType.TEN_PERCENT_DISCOUNT, bundle_offer_product_quantities, 10)
         receipt = self.teller.checks_out_articles_from(self.the_cart)
         verify(ReceiptPrinter(40).print_receipt(receipt))
+
+    def test_percent_discount_on_multiple_bundles(self):
+        self.the_cart.add_item_quantity(self.apples, 2.0)
+        self.the_cart.add_item_quantity(self.rice, 1.0)
+        self.the_cart.add_item_quantity(self.cherry_tomatoes, 3.0)
+        self.the_cart.add_item_quantity(self.toothbrush, 1)
+        self.the_cart.add_item_quantity(self.toothpaste, 1)
+        bundle_offer_1 = {
+            self.apples: 1.0,
+            self.rice: 1.0
+        }
+        bundle_offer_2 = {
+            self.toothbrush: 1,
+            self.toothpaste: 1
+        }
+        self.teller.add_bundle_offer(BundleOfferType.TEN_PERCENT_DISCOUNT, bundle_offer_1, 10)
+        self.teller.add_bundle_offer(BundleOfferType.TEN_PERCENT_DISCOUNT, bundle_offer_2, 10)
+        receipt = self.teller.checks_out_articles_from(self.the_cart)
+        verify(ReceiptPrinter(40).print_receipt(receipt))

--- a/python/tests/test_supermarket.py
+++ b/python/tests/test_supermarket.py
@@ -216,3 +216,17 @@ class SupermarketTest(unittest.TestCase):
         self.teller.add_bundle_offer(BundleOfferType.TEN_PERCENT_DISCOUNT, bundle_offer_2, 10)
         receipt = self.teller.checks_out_articles_from(self.the_cart)
         verify(ReceiptPrinter(40).print_receipt(receipt))
+
+    def test_bundle_offer_and_single_offer_together(self):
+        self.the_cart.add_item_quantity(self.toothbrush, 1)
+        self.the_cart.add_item_quantity(self.toothpaste, 1)
+        self.the_cart.add_item_quantity(self.rice, 3)
+        bundle_offer_product_quantities = {
+            self.toothbrush: 1,
+            self.toothpaste: 1
+        }
+        self.teller.add_bundle_offer(BundleOfferType.TEN_PERCENT_DISCOUNT, bundle_offer_product_quantities, 10)
+        self.teller.add_special_offer(SpecialOfferType.THREE_FOR_TWO, self.rice,
+                                      self.catalog.unit_price(self.rice))
+        receipt = self.teller.checks_out_articles_from(self.the_cart)
+        verify(ReceiptPrinter(40).print_receipt(receipt))

--- a/python/tests/test_supermarket.py
+++ b/python/tests/test_supermarket.py
@@ -199,3 +199,20 @@ class SupermarketTest(unittest.TestCase):
         self.teller.add_bundle_offer(BundleOfferType.TEN_PERCENT_DISCOUNT, bundle_offer_2, 10)
         receipt = self.teller.checks_out_articles_from(self.the_cart)
         verify(ReceiptPrinter(40).print_receipt(receipt))
+
+    def test_percent_discount_on_multiple_bundles_with_redundant_item(self):
+        self.the_cart.add_item_quantity(self.rice, 1.0)
+        self.the_cart.add_item_quantity(self.toothbrush, 10)
+        self.the_cart.add_item_quantity(self.toothpaste, 10)
+        bundle_offer_1 = {
+            self.toothpaste: 5,
+            self.rice: 1.0
+        }
+        bundle_offer_2 = {
+            self.toothbrush: 1,
+            self.toothpaste: 1
+        }
+        self.teller.add_bundle_offer(BundleOfferType.TEN_PERCENT_DISCOUNT, bundle_offer_1, 10)
+        self.teller.add_bundle_offer(BundleOfferType.TEN_PERCENT_DISCOUNT, bundle_offer_2, 10)
+        receipt = self.teller.checks_out_articles_from(self.the_cart)
+        verify(ReceiptPrinter(40).print_receipt(receipt))


### PR DESCRIPTION
### Changes:
- Added implementation for Bundle Offers
- Added `pytest` tests for bundle offers

### How to test:
- Run command `pytest`. All tests should pass.
- Verify all new tests are correct according to Bundle Offer feature requirements.

---

### Assumptions & Scope Limitations
In general, the Bundle Offers can be used in different ways and there can be a number of scenarios. This implementation has following limitations:
- If single product appears in bundle offers as well as in individual product offers, the bundle offer takes precedence.
- If single product appears in multiple bundle offers, only one with the highest discount amount gets applied for that product.
---

### Tests:
- New `pytest` tests have been added for the bundle offers.
- `texttest` tests have NOT been added for the bundle offers.
